### PR TITLE
feat: 添加刮削后再次遍历 STRM 开关

### DIFF
--- a/backend/src/main/java/com/hienao/openlist2strm/dto/task/TaskConfigDto.java
+++ b/backend/src/main/java/com/hienao/openlist2strm/dto/task/TaskConfigDto.java
@@ -32,6 +32,9 @@ public class TaskConfigDto {
   /** 是否需要刮削：true-需要，false-不需要 */
   private Boolean needScrap;
 
+  /** 刮削后是否再次遍历 STRM 目录：true-需要，false-不需要 */
+  private Boolean rescanStrmAfterScraping;
+
   /** 重命名正则表达式，为空时表示不需要重命名 */
   @Size(max = 500, message = "重命名正则表达式长度不能超过500个字符") private String renameRegex;
 

--- a/backend/src/main/java/com/hienao/openlist2strm/entity/TaskConfig.java
+++ b/backend/src/main/java/com/hienao/openlist2strm/entity/TaskConfig.java
@@ -31,6 +31,9 @@ public class TaskConfig {
   /** 是否需要刮削：true-是，false-否 */
   private Boolean needScrap;
 
+  /** 刮削后是否再次遍历 STRM 目录：true-是，false-否 */
+  private Boolean rescanStrmAfterScraping;
+
   /** 重命名正则表达式，为空时表示不需要重命名 */
   private String renameRegex;
 

--- a/backend/src/main/java/com/hienao/openlist2strm/handler/FileDiscoveryHandler.java
+++ b/backend/src/main/java/com/hienao/openlist2strm/handler/FileDiscoveryHandler.java
@@ -35,6 +35,11 @@ public class FileDiscoveryHandler implements FileProcessorHandler {
   @Override
   public ProcessingResult process(FileProcessingContext context) {
     try {
+      if (context.getCurrentFile() != null) {
+        log.trace("单文件上下文已包含当前文件，跳过文件发现: {}", context.getCurrentFile().getPath());
+        return ProcessingResult.SUCCESS;
+      }
+
       log.debug("开始文件发现: {}", context.getRelativePath());
 
       List<OpenlistApiService.OpenlistFile> allFiles = new ArrayList<>();

--- a/backend/src/main/java/com/hienao/openlist2strm/handler/MediaScrapingHandler.java
+++ b/backend/src/main/java/com/hienao/openlist2strm/handler/MediaScrapingHandler.java
@@ -56,6 +56,12 @@ public class MediaScrapingHandler implements FileProcessorHandler {
         return ProcessingResult.SKIPPED;
       }
 
+      if (!Boolean.TRUE.equals(context.getTaskConfig().getNeedScrap())) {
+        log.debug("当前任务未开启需要刮削，跳过: {}", context.getBaseFileName());
+        context.getStats().incrementSkipped();
+        return ProcessingResult.SKIPPED;
+      }
+
       // 检查 TMDB API Key
       if (!isTmdbConfigured(context)) {
         log.warn("TMDB API Key 未配置，跳过刮削");

--- a/backend/src/main/java/com/hienao/openlist2strm/handler/OrphanCleanupHandler.java
+++ b/backend/src/main/java/com/hienao/openlist2strm/handler/OrphanCleanupHandler.java
@@ -43,6 +43,11 @@ public class OrphanCleanupHandler implements FileProcessorHandler {
   @Override
   public ProcessingResult process(FileProcessingContext context) {
     try {
+      if (context.getCurrentFile() != null) {
+        log.trace("单文件上下文跳过孤立文件清理: {}", context.getCurrentFile().getPath());
+        return ProcessingResult.SKIPPED;
+      }
+
       // 只在增量模式下执行清理
       if (!Boolean.TRUE.equals(context.getTaskConfig().getIsIncrement())) {
         log.debug("非增量模式，跳过孤立文件清理");

--- a/backend/src/main/java/com/hienao/openlist2strm/service/StrmRescanService.java
+++ b/backend/src/main/java/com/hienao/openlist2strm/service/StrmRescanService.java
@@ -1,0 +1,126 @@
+package com.hienao.openlist2strm.service;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Locale;
+import java.util.concurrent.atomic.AtomicInteger;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
+
+/** STRM 目录再次遍历服务。 */
+@Slf4j
+@Service
+public class StrmRescanService {
+
+  /** 再次遍历 STRM 目录并输出统计信息。 */
+  public StrmRescanResult rescanStrmDirectory(String strmBasePath) {
+    if (!StringUtils.hasText(strmBasePath)) {
+      log.warn("STRM基础路径为空，跳过再次遍历");
+      return StrmRescanResult.empty(strmBasePath);
+    }
+
+    Path strmPath = Paths.get(strmBasePath);
+    if (!isReadableDirectory(strmPath)) {
+      log.info("STRM目录不存在、不可访问或不是目录，跳过再次遍历: {}", strmPath);
+      return StrmRescanResult.empty(strmBasePath);
+    }
+
+    StrmRescanCounters counters = scanStrmPath(strmPath, strmBasePath);
+    StrmRescanResult result = counters.toResult(strmBasePath);
+    logResult(result);
+    return result;
+  }
+
+  private StrmRescanCounters scanStrmPath(Path strmPath, String strmBasePath) {
+    StrmRescanCounters counters = new StrmRescanCounters();
+    try (java.util.stream.Stream<Path> pathStream = Files.walk(strmPath)) {
+      pathStream.filter(path -> !path.equals(strmPath)).forEach(counters::accept);
+    } catch (IOException | UncheckedIOException | SecurityException e) {
+      log.warn("再次遍历STRM目录失败: {}, 错误: {}", strmBasePath, e.getMessage());
+    }
+    return counters;
+  }
+
+  private boolean isReadableDirectory(Path path) {
+    try {
+      return Files.exists(path) && Files.isDirectory(path);
+    } catch (SecurityException e) {
+      log.warn("STRM目录不可访问，跳过再次遍历: {}, 错误: {}", path, e.getMessage());
+      return false;
+    }
+  }
+
+  private void logResult(StrmRescanResult result) {
+    log.info(
+        "再次遍历STRM目录完成: path={}, directories={}, strmFiles={}, scrapingFiles={}, otherFiles={}",
+        result.strmBasePath(),
+        result.directoryCount(),
+        result.strmFileCount(),
+        result.scrapingFileCount(),
+        result.otherFileCount());
+  }
+
+  private boolean isStrmFile(Path path) {
+    return path.getFileName().toString().toLowerCase(Locale.ROOT).endsWith(".strm");
+  }
+
+  private boolean isScrapingMetadataFile(Path path) {
+    String fileName = path.getFileName().toString().toLowerCase(Locale.ROOT);
+    return fileName.endsWith(".nfo")
+        || fileName.endsWith(".jpg")
+        || fileName.endsWith(".jpeg")
+        || fileName.endsWith(".png")
+        || fileName.endsWith(".webp")
+        || fileName.endsWith(".bmp")
+        || fileName.endsWith(".xml");
+  }
+
+  public record StrmRescanResult(
+      String strmBasePath,
+      int directoryCount,
+      int strmFileCount,
+      int scrapingFileCount,
+      int otherFileCount) {
+
+    public static StrmRescanResult empty(String strmBasePath) {
+      return new StrmRescanResult(strmBasePath, 0, 0, 0, 0);
+    }
+  }
+
+  private class StrmRescanCounters {
+    private final AtomicInteger directoryCount = new AtomicInteger();
+    private final AtomicInteger strmFileCount = new AtomicInteger();
+    private final AtomicInteger scrapingFileCount = new AtomicInteger();
+    private final AtomicInteger otherFileCount = new AtomicInteger();
+
+    private void accept(Path path) {
+      try {
+        if (Files.isDirectory(path)) {
+          directoryCount.incrementAndGet();
+        } else if (isStrmFile(path)) {
+          strmFileCount.incrementAndGet();
+        } else if (isScrapingMetadataFile(path)) {
+          scrapingFileCount.incrementAndGet();
+        } else {
+          otherFileCount.incrementAndGet();
+        }
+      } catch (SecurityException e) {
+        otherFileCount.incrementAndGet();
+        log.debug("再次遍历STRM时跳过不可访问路径: {}, 错误: {}", path, e.getMessage());
+      }
+    }
+
+    private StrmRescanResult toResult(String strmBasePath) {
+      return new StrmRescanResult(
+          strmBasePath,
+          directoryCount.get(),
+          strmFileCount.get(),
+          scrapingFileCount.get(),
+          otherFileCount.get());
+    }
+  }
+}

--- a/backend/src/main/java/com/hienao/openlist2strm/service/TaskConfigService.java
+++ b/backend/src/main/java/com/hienao/openlist2strm/service/TaskConfigService.java
@@ -129,6 +129,7 @@ public class TaskConfigService {
 
     // 设置默认值
     setDefaultValues(taskConfig);
+    normalizeScrapingOptions(taskConfig);
 
     int result = taskConfigMapper.insert(taskConfig);
     if (result <= 0) {
@@ -185,6 +186,12 @@ public class TaskConfigService {
         throw new BusinessException("任务路径已存在: " + taskConfig.getPath());
       }
     }
+
+    Boolean effectiveNeedScrap =
+        taskConfig.getNeedScrap() != null
+            ? taskConfig.getNeedScrap()
+            : existingConfig.getNeedScrap();
+    normalizeScrapingOptions(taskConfig, effectiveNeedScrap);
 
     int result = taskConfigMapper.updateById(taskConfig);
     if (result <= 0) {
@@ -378,6 +385,9 @@ public class TaskConfigService {
     if (taskConfig.getNeedScrap() == null) {
       taskConfig.setNeedScrap(false);
     }
+    if (taskConfig.getRescanStrmAfterScraping() == null) {
+      taskConfig.setRescanStrmAfterScraping(false);
+    }
     if (taskConfig.getRenameRegex() == null) {
       taskConfig.setRenameRegex("");
     }
@@ -395,6 +405,16 @@ public class TaskConfigService {
     }
     if (taskConfig.getIsActive() == null) {
       taskConfig.setIsActive(true);
+    }
+  }
+
+  private void normalizeScrapingOptions(TaskConfig taskConfig) {
+    normalizeScrapingOptions(taskConfig, taskConfig.getNeedScrap());
+  }
+
+  private void normalizeScrapingOptions(TaskConfig taskConfig, Boolean effectiveNeedScrap) {
+    if (!Boolean.TRUE.equals(effectiveNeedScrap)) {
+      taskConfig.setRescanStrmAfterScraping(false);
     }
   }
 }

--- a/backend/src/main/java/com/hienao/openlist2strm/service/TaskExecutionService.java
+++ b/backend/src/main/java/com/hienao/openlist2strm/service/TaskExecutionService.java
@@ -50,6 +50,7 @@ public class TaskExecutionService {
   private final OpenlistApiService openlistApiService;
   private final StrmFileService strmFileService;
   private final MediaScrapingService mediaScrapingService;
+  private final StrmRescanService strmRescanService;
   private final SystemConfigService systemConfigService;
   private final FileProcessorChain fileProcessorChain;
   private final Executor taskSubmitExecutor;
@@ -289,6 +290,14 @@ public class TaskExecutionService {
               openlistConfig);
       log.info("清理了 {} 个孤立的STRM文件", cleanedCount);
     }
+
+    // 9. 按任务配置在刮削流程结束后再次遍历 STRM 目录
+    if (needScrap
+        && Boolean.TRUE.equals(scrapingConfig.getOrDefault("enabled", true))
+        && Boolean.TRUE.equals(taskConfig.getRescanStrmAfterScraping())) {
+      log.info("任务开启刮削后再次遍历STRM，开始扫描: {}", taskConfig.getStrmPath());
+      strmRescanService.rescanStrmDirectory(taskConfig.getStrmPath());
+    }
   }
 
   /** 创建单个文件的处理上下文 */
@@ -326,6 +335,13 @@ public class TaskExecutionService {
                 })
             .toList();
 
+    java.util.HashMap<String, Object> attributes =
+        scrapingConfig != null
+            ? new java.util.HashMap<>(scrapingConfig)
+            : new java.util.HashMap<>();
+    attributes.put("discoveredFiles", directoryFiles);
+    attributes.put("originalFiles", directoryFiles);
+
     return FileProcessingContext.builder()
         .openlistConfig(openlistConfig)
         .taskConfig(parentContext.getTaskConfig())
@@ -334,10 +350,7 @@ public class TaskExecutionService {
         .saveDirectory(saveDirectory)
         .baseFileName(baseFileName)
         .directoryFiles(currentDirFiles)
-        .attributes(
-            scrapingConfig != null
-                ? new java.util.HashMap<>(scrapingConfig)
-                : new java.util.HashMap<>())
+        .attributes(attributes)
         .build();
   }
 

--- a/backend/src/main/resources/db/migration/V1_0_8__add_rescan_strm_after_scraping_column.sql
+++ b/backend/src/main/resources/db/migration/V1_0_8__add_rescan_strm_after_scraping_column.sql
@@ -1,0 +1,2 @@
+-- 添加任务级开关：刮削后是否再次遍历 STRM 目录
+ALTER TABLE task_config ADD COLUMN rescan_strm_after_scraping INTEGER DEFAULT 0;

--- a/backend/src/main/resources/mapper/TaskConfigMapper.xml
+++ b/backend/src/main/resources/mapper/TaskConfigMapper.xml
@@ -9,6 +9,7 @@
         <result column="path" property="path" jdbcType="VARCHAR"/>
         <result column="openlist_config_id" property="openlistConfigId" jdbcType="BIGINT"/>
         <result column="need_scrap" property="needScrap" jdbcType="BOOLEAN"/>
+        <result column="rescan_strm_after_scraping" property="rescanStrmAfterScraping" jdbcType="BOOLEAN"/>
         <result column="rename_regex" property="renameRegex" jdbcType="VARCHAR"/>
         <result column="cron" property="cron" jdbcType="VARCHAR"/>
         <result column="is_increment" property="isIncrement" jdbcType="BOOLEAN"/>
@@ -21,7 +22,7 @@
 
     <!-- 基础字段 -->
     <sql id="Base_Column_List">
-        id, task_name, path, openlist_config_id, need_scrap, rename_regex, cron, is_increment, strm_path, last_exec_time, created_at, updated_at, is_active
+        id, task_name, path, openlist_config_id, need_scrap, rescan_strm_after_scraping, rename_regex, cron, is_increment, strm_path, last_exec_time, created_at, updated_at, is_active
     </sql>
 
     <!-- 根据ID查询 -->
@@ -92,6 +93,9 @@
             <if test="needScrap != null">
                 need_scrap,
             </if>
+            <if test="rescanStrmAfterScraping != null">
+                rescan_strm_after_scraping,
+            </if>
             <if test="renameRegex != null">
                 rename_regex,
             </if>
@@ -123,6 +127,9 @@
             </if>
             <if test="needScrap != null">
                 #{needScrap},
+            </if>
+            <if test="rescanStrmAfterScraping != null">
+                #{rescanStrmAfterScraping},
             </if>
             <if test="renameRegex != null">
                 #{renameRegex},
@@ -160,6 +167,9 @@
             </if>
             <if test="needScrap != null">
                 need_scrap = #{needScrap},
+            </if>
+            <if test="rescanStrmAfterScraping != null">
+                rescan_strm_after_scraping = #{rescanStrmAfterScraping},
             </if>
             <if test="renameRegex != null">
                 rename_regex = #{renameRegex},

--- a/frontend/app/pages/task-management/[id].vue
+++ b/frontend/app/pages/task-management/[id].vue
@@ -132,6 +132,10 @@
                 <input type="checkbox" :checked="task.needScrap" disabled class="mr-2 h-4 w-4 rounded border-white/20 bg-white/5 text-blue-500">
                 需要刮削
               </label>
+              <label v-if="task.needScrap" class="flex items-center text-sm text-white/60">
+                <input type="checkbox" :checked="task.rescanStrmAfterScraping" disabled class="mr-2 h-4 w-4 rounded border-white/20 bg-white/5 text-blue-500">
+                刮削后再次遍历STRM
+              </label>
               <label class="flex items-center text-sm text-white/60">
                 <input type="checkbox" :checked="task.isIncrement" disabled class="mr-2 h-4 w-4 rounded border-white/20 bg-white/5 text-blue-500">
                 增量更新
@@ -247,6 +251,14 @@
                   </span>
                 </label>
 
+                <label v-if="taskForm.needScrap" class="flex items-start cursor-pointer">
+                  <input v-model="taskForm.rescanStrmAfterScraping" type="checkbox" class="mt-1 h-4 w-4 rounded border-white/20 bg-white/5 text-blue-500">
+                  <span class="ml-2 text-sm text-white/70">
+                    刮削后再次遍历STRM
+                    <span class="block text-xs text-white/40 mt-0.5">任务刮削流程结束后，再扫描一次当前STRM输出目录</span>
+                  </span>
+                </label>
+
                 <label class="flex items-center cursor-pointer">
                   <input v-model="taskForm.isIncrement" type="checkbox" class="h-4 w-4 rounded border-white/20 bg-white/5 text-blue-500">
                   <span class="ml-2 text-sm text-white/70">增量更新</span>
@@ -319,7 +331,7 @@
 </template>
 
 <script setup>
-import { ref, onMounted } from 'vue'
+import { ref, onMounted, watch } from 'vue'
 import logger from '~/core/utils/logger'
 import { useRoute, useRouter } from 'vue-router'
 import { apiCall, authenticatedApiCall } from '~/core/api/client'
@@ -344,12 +356,22 @@ const taskForm = ref({
   strmPath: '/app/backend/strm',
   cron: '',
   needScrap: false,
+  rescanStrmAfterScraping: false,
   renameRegex: '',
   isIncrement: true,
   isActive: true
 })
 const strmSubPath = ref('')
 const showRenameRegexHelp = ref(false)
+
+watch(
+  () => taskForm.value.needScrap,
+  (needScrap) => {
+    if (!needScrap) {
+      taskForm.value.rescanStrmAfterScraping = false
+    }
+  }
+)
 
 const getConfigInfo = async () => {
   try {
@@ -383,7 +405,7 @@ const fetchTasks = async () => {
 const resetTaskForm = () => {
   taskForm.value = {
     taskName: '', path: '', strmPath: '/app/backend/strm', cron: '',
-    needScrap: false, renameRegex: '', isIncrement: true, isActive: true
+    needScrap: false, rescanStrmAfterScraping: false, renameRegex: '', isIncrement: true, isActive: true
   }
   strmSubPath.value = ''
   showRenameRegexHelp.value = false
@@ -391,9 +413,11 @@ const resetTaskForm = () => {
 
 const editTask = (task) => {
   editingTaskId.value = task.id
+  const needScrap = task.needScrap || false
   taskForm.value = {
     taskName: task.taskName, path: task.path, strmPath: task.strmPath,
-    cron: task.cron || '', needScrap: task.needScrap || false,
+    cron: task.cron || '', needScrap,
+    rescanStrmAfterScraping: needScrap ? task.rescanStrmAfterScraping || false : false,
     renameRegex: task.renameRegex || '', isIncrement: task.isIncrement, isActive: task.isActive
   }
   const prefix = '/app/backend/strm/'
@@ -420,6 +444,7 @@ const submitTask = async () => {
     if (taskForm.value.path) await validateTaskPath(taskForm.value.path)
     const fullStrmPath = '/app/backend/strm/' + (strmSubPath.value || '')
     const taskData = { ...taskForm.value, strmPath: fullStrmPath, openlistConfigId: parseInt(configId) }
+    if (!taskData.needScrap) taskData.rescanStrmAfterScraping = false
     let response
     if (showCreateTaskModal.value) {
       response = await authenticatedApiCall('/task-config', { method: 'POST', body: taskData })


### PR DESCRIPTION
目前发现开启刮削功能后，每次刮削完都会重新便利一次STRM 源目录 ，在处理大批量，稳定文件的情况下，会消耗过多的时间，因此本次新增任务级配置项：是否在媒体刮削完成后再次遍历 STRM 输出目录。方便文件数量少，存在动态文件更新的情况的用户。

## 变更内容

本次新增任务级配置项：是否在媒体刮削完成后再次遍历 STRM 输出目录。

### 后端

- 新增 `rescan_strm_after_scraping` 数据库字段与 Flyway 迁移
- `TaskConfig` / `TaskConfigDto` / MyBatis 映射支持新字段
- 新增 `StrmRescanService`，用于扫描 STRM 输出目录并记录统计信息
- 在任务执行流程中，仅当以下条件全部满足时执行再次遍历：
  - 任务开启 `needScrap`
  - 系统刮削配置开启
  - 任务开启 `rescanStrmAfterScraping`
- 修复单文件处理链中重复执行文件发现/孤立清理的问题
- `MediaScrapingHandler` 现在会尊重任务级 `needScrap`
- 补强 STRM 再次遍历异常处理，避免不可读/被删除文件导致任务失败
- 后端创建/更新任务时会兜底清理无效配置：`needScrap=false` 时强制 `rescanStrmAfterScraping=false`

### 前端

- 任务管理页面新增“刮削后再次遍历 STRM”开关
- 该选项仅在“需要刮削”开启时展示
- 关闭“需要刮削”时自动清空该配置
- 提交前兜底清理无效配置，避免用户保存后实际不生效造成误导

## 验证

- 已执行 `git diff --check`
- 已执行聚焦静态检查，覆盖：
  - 后端异常捕获
  - 后端配置规范化
  - 前端开关显示条件
  - 前端 watcher 清空逻辑
  - 前端 submit 兜底逻辑

## 注意事项

当前环境未完成完整构建验证：
- 后端依赖下载存在 Maven TLS handshake 问题
- 前端本地缺少 `node_modules/nuxt`

建议 CI 或依赖环境恢复后再执行完整构建验证。