### PR TITLE
Fix GitHub Release changelog handling

### DIFF
--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -264,16 +264,17 @@ jobs:
       if: needs.build-amd64.outputs.is_beta != 'true'
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        VERSION: ${{ needs.build-amd64.outputs.version }}
+        CHANGELOG: ${{ steps.github_release.outputs.changelog }}
       run: |
-        VERSION="${{ needs.build-amd64.outputs.version }}"
-        CHANGELOG="${{ steps.github_release.outputs.changelog }}"
         if [ -z "$CHANGELOG" ] || [ "$CHANGELOG" = "- No changes" ]; then
           CHANGELOG="Release ${VERSION}"
         fi
+        printf '%s\n' "$CHANGELOG" > release-notes.md
         gh release create "${VERSION}" \
           --target main \
           --title "Release ${VERSION}" \
-          --notes "${CHANGELOG}" \
+          --notes-file release-notes.md \
           --latest \
           "ostrm-${VERSION}-source.zip"
 


### PR DESCRIPTION
## 问题

GitHub Release 步骤将自动生成的 changelog 直接插入 shell 双引号字符串。历史提交标题包含反引号时，会触发 shell 命令替换并导致发布失败。

## 修复

- VERSION 和 CHANGELOG 通过步骤环境变量传递
- changelog 使用 printf 写入 release-notes.md
- gh release create 改用 notes-file，完整保留多行内容和特殊字符

v2.5.0 Release 已手动补建，本 PR 用于防止后续正式版本复现。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved release publishing to consistently include formatted release notes.
  * Preserved fallback behavior when changelog content is unavailable.
  * No changes to publicly exported features or end-user functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->