### PR TITLE
Release beta-v2.5.14

### DIFF
--- a/app_version.json
+++ b/app_version.json
@@ -1,4 +1,4 @@
 {
   "release_version": "v2.5.0",
-  "beta_version": "beta-v2.5.13"
+  "beta_version": "beta-v2.5.14"
 }

--- a/backend/src/main/java/com/hienao/openlist2strm/service/MediaServerApiService.java
+++ b/backend/src/main/java/com/hienao/openlist2strm/service/MediaServerApiService.java
@@ -11,6 +11,7 @@ import com.hienao.openlist2strm.exception.BusinessException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
@@ -30,6 +31,7 @@ public class MediaServerApiService {
   private final ObjectMapper objectMapper;
   private final RestTemplate restTemplate;
 
+  @Autowired
   public MediaServerApiService(MediaServerConfigService configService, ObjectMapper objectMapper) {
     this(configService, objectMapper, createRestTemplate());
   }

--- a/backend/src/test/java/com/hienao/openlist2strm/service/MediaServerApiServiceTest.java
+++ b/backend/src/test/java/com/hienao/openlist2strm/service/MediaServerApiServiceTest.java
@@ -1,6 +1,8 @@
 package com.hienao.openlist2strm.service;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.Mockito.mock;
 import static org.springframework.test.web.client.match.MockRestRequestMatchers.content;
 import static org.springframework.test.web.client.match.MockRestRequestMatchers.header;
 import static org.springframework.test.web.client.match.MockRestRequestMatchers.method;
@@ -12,6 +14,7 @@ import com.hienao.openlist2strm.entity.MediaRefreshScope;
 import com.hienao.openlist2strm.entity.MediaServerConfig;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.client.MockRestServiceServer;
@@ -27,6 +30,20 @@ class MediaServerApiServiceTest {
     RestTemplate restTemplate = new RestTemplate();
     server = MockRestServiceServer.bindTo(restTemplate).build();
     service = new MediaServerApiService(null, new ObjectMapper(), restTemplate);
+  }
+
+  @Test
+  void springCanCreateServiceWhenTestConstructorAlsoExists() {
+    try (AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext()) {
+      context.registerBean(
+          MediaServerConfigService.class, () -> mock(MediaServerConfigService.class));
+      context.registerBean(ObjectMapper.class, () -> new ObjectMapper());
+      context.register(MediaServerApiService.class);
+
+      context.refresh();
+
+      assertNotNull(context.getBean(MediaServerApiService.class));
+    }
   }
 
   @Test


### PR DESCRIPTION
## 修复内容

- 修复 `MediaServerApiService` 存在多个构造器时 Spring 无法选择注入构造器，导致容器启动失败的问题
- 新增 Spring 容器实例化回归测试

## 验证

- 后端 `spotlessCheck test bootJar` 通过
- Spring 容器可成功创建 `MediaServerApiService`

## 发布

- Beta 版本：`beta-v2.5.14`
- 目标分支：`beta`